### PR TITLE
Script enhancement and compatible with iOS 8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ What frameworks are available?
 ---
 - SDL2
 - SDL2_image
-- SDL2_mixer
+- SDL2_mixer (with ogg vorbis support through the embedded Tremor)
 - SDL2_ttf
-- Tremor *(SDL2_mixer contains its own copy now)*
 
 How to use?
 ---

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,7 @@ module Builder
 		args << %{CONFIGURATION_BUILD_DIR="#{dest}"}
 		args << %{CONFIGURATION_TEMP_DIR="#{dest}.build"}
 
+# this logic is suggested here: http://blog.diogot.com/blog/2013/09/18/static-libs-with-support-to-ios-5-and-arm64/
         target = '5.0'
         if arch == 'arm64'
             target = '7.0'


### PR DESCRIPTION
I've modified the script to build the head versions of SDL and always use a fat binary architecture, so that the resulting framework can be linked to any iOS target.

Since february Apple requires that iOS apps support "arm64" target for iOS store submission.

This modified version implements also the magic needed to build a library compatible with ipad1 with a modern SDK, as described here:

http://blog.diogot.com/blog/2013/09/18/static-libs-with-support-to-ios-5-and-arm64/
